### PR TITLE
Scrollbar issues on Windows

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -9,17 +9,17 @@
 }
 
 .scrollbars-visible-always {
-  ::-webkit-scrollbar {
+  /deep/ ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
 
-  ::-webkit-scrollbar-track,
-  ::-webkit-scrollbar-corner {
+  /deep/ ::-webkit-scrollbar-track,
+  /deep/ ::-webkit-scrollbar-corner {
     background: @scrollbar-background-color;
   }
 
-  ::-webkit-scrollbar-thumb {
+  /deep/ ::-webkit-scrollbar-thumb {
     background: @scrollbar-color;
     border-radius: 5px;
     box-shadow: 0 0 1px black inset;


### PR DESCRIPTION
Even when the theme is applied, the scrollbars looked like default Windows scrollbars (like crap). Since Atom and One UIs are also adding `/deep/` to the scrollbar styles, I tried that on my styles.less and that seemed to fix my issue.
